### PR TITLE
API key can now be set on each request

### DIFF
--- a/lib/app_monit/http.rb
+++ b/lib/app_monit/http.rb
@@ -39,13 +39,26 @@ module AppMonit
       end
 
       # set headers so event data ends up in the correct bucket on the other side
-      request.add_field('Appmonit-Api-Key', AppMonit::Config.api_key)
+      # only add Appmonit-Api-Key header if there was no api_key configured in the params
+      request.add_field('Appmonit-Api-Key', AppMonit::Config.api_key) unless api_key(path)
       request.add_field('Appmonit-Env', AppMonit::Config.env)
       response = client.request(request)
 
       raise Error.new("Invalid response code: #{response.code} body: #{response.body}") unless SUCCESS_CODES.include?(response.code)
 
       response
+    end
+
+    private
+
+    def api_key(path)
+      params(path).fetch('api_key', nil)
+    end
+
+    def params(path)
+      URI.decode_www_form(URI.parse(path).query).to_h
+    rescue
+      {}
     end
   end
 end

--- a/lib/app_monit/version.rb
+++ b/lib/app_monit/version.rb
@@ -1,3 +1,3 @@
 module AppMonit
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/spec/app_monit/query_spec.rb
+++ b/spec/app_monit/query_spec.rb
@@ -9,17 +9,36 @@ describe AppMonit::Query do
     AppMonit::Config.env       = nil
   end
 
-  %w(count count_unique minimum maximum average sum funnel).each do |method_name|
-    describe method_name do
-      it 'gets the results with the given params' do
-        stub_request(:get, /api.appmon.it\/v1\/queries\/#{method_name}/).to_return(body: {result: '0'}.to_json)
+  describe 'No api_key has been added to the params' do
+    %w(count count_unique minimum maximum average sum funnel).each do |method_name|
+      describe method_name do
+        it 'gets the results with the given params' do
+          stub_request(:get, /api.appmon.it\/v1\/queries\/#{method_name}/).to_return(body: {result: '0'}.to_json)
 
-        params = { valid: 'params' }
-        subject.send(method_name, 'collection_name', params)
+          params = { valid: 'params' }
+          subject.send(method_name, 'collection_name', params)
 
-        params[:event_collection] = 'collection_name'
+          params[:event_collection] = 'collection_name'
 
-        assert_requested(:get, /api.appmon.it\/v1\/queries\/#{method_name}\?query=#{params.to_json}/)
+          assert_requested(:get, /api.appmon.it\/v1\/queries\/#{method_name}\?query=#{params.to_json}/)
+        end
+      end
+    end
+  end
+
+  describe 'An api_key has been added to the params' do
+    %w(count count_unique minimum maximum average sum funnel).each do |method_name|
+      describe method_name do
+        it 'gets the results with the given params' do
+          stub_request(:get, /api.appmon.it\/v1\/queries\/#{method_name}/).to_return(body: {result: '0'}.to_json)
+
+          params = { valid: 'params', api_key: 'XXX' }
+          subject.send(method_name, 'collection_name', params)
+
+          params[:event_collection] = 'collection_name'
+
+          assert_requested(:get, /api.appmon.it\/v1\/queries\/#{method_name}\?api_key=XXX&query=#{params.to_json}/)
+        end
       end
     end
   end


### PR DESCRIPTION
By adding a param named `api_key` when doing requests it is now possible to change the API key on each request, instead of only configuring it once for the application which uses this gem.
